### PR TITLE
Modification of input

### DIFF
--- a/src/Forms/Controls/PhoneNumberInput.php
+++ b/src/Forms/Controls/PhoneNumberInput.php
@@ -49,7 +49,7 @@ class PhoneNumberInput extends BaseControl
 	{
 		$container->addComponent($control = new self($label), $name);
 
-		$control->container = Html::el('div')->setAttribute('class', 'input-group');
+		$control->container = Html::el('div')->setAttribute('class', 'input-group phone-number-input-group');
 		$control->controls[static::CONTROL_COUNTRY_CODE] = Html::el();
 		$control->controls[static::CONTROL_NATIONAL_NUMBER] = Html::el();
 		$control->setDefaultCountryCode(self::getDefaultCountryCodeByIP());
@@ -88,13 +88,23 @@ class PhoneNumberInput extends BaseControl
 	 */
 	public function getControl()
 	{
-		$inputGroup = Html::el('div')->setAttribute('class', 'input-group');
+		$html = '';
 
 		foreach (self::CONTROLS as $key) {
-			$inputGroup->addHtml($this->getControlPart($key));
+			$html .= $this->getControlPart($key);
 		}
 
-		return $this->container->setHtml($inputGroup);
+		$style = Html::el('style')->setHtml(
+		// Select (hidden by Select2, but keeps structure correct)
+			'.phone-number-input-group > select { flex: 0 0 auto; width: auto; border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
+			// Select2 container
+			. ' .phone-number-input-group > .select2-container { flex: 0 0 auto; }'
+			. ' .phone-number-input-group > .select2-container .select2-selection { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
+			// Text input
+			. ' .phone-number-input-group > input[type="tel"] { flex: 1 1 auto; border-top-left-radius: 0 !important; border-bottom-left-radius: 0 !important; }'
+		);
+
+		return $this->container->setHtml($html . $style);
 	}
 
 	protected function getCountryCodes()

--- a/src/Forms/Controls/PhoneNumberInput.php
+++ b/src/Forms/Controls/PhoneNumberInput.php
@@ -88,13 +88,14 @@ class PhoneNumberInput extends BaseControl
 	 */
 	public function getControl()
 	{
-		$html = '';
+		$countryCode = $this->getControlPart(self::CONTROL_COUNTRY_CODE);
+		$nationalNumber = $this->getControlPart(self::CONTROL_NATIONAL_NUMBER);
 
-		foreach (self::CONTROLS as $key) {
-			$html .= $this->getControlPart($key);
-		}
+		$inputGroup = Html::el('div')->setAttribute('class', 'input-group');
+		$inputGroup->addHtml($countryCode);
+		$inputGroup->addHtml($nationalNumber);
 
-		return $this->container->setHtml($html);
+		return $this->container->setHtml($inputGroup);
 	}
 
 	protected function getCountryCodes()

--- a/src/Forms/Controls/PhoneNumberInput.php
+++ b/src/Forms/Controls/PhoneNumberInput.php
@@ -49,7 +49,7 @@ class PhoneNumberInput extends BaseControl
 	{
 		$container->addComponent($control = new self($label), $name);
 
-		$control->container = Html::el();
+		$control->container = Html::el('div')->setAttribute('class', 'input-group');
 		$control->controls[static::CONTROL_COUNTRY_CODE] = Html::el();
 		$control->controls[static::CONTROL_NATIONAL_NUMBER] = Html::el();
 		$control->setDefaultCountryCode(self::getDefaultCountryCodeByIP());
@@ -88,13 +88,13 @@ class PhoneNumberInput extends BaseControl
 	 */
 	public function getControl()
 	{
-		$html = '';
+		$inputGroup = Html::el('div')->setAttribute('class', 'input-group');
 
 		foreach (self::CONTROLS as $key) {
-			$html .= $this->getControlPart($key);
+			$inputGroup->addHtml($this->getControlPart($key));
 		}
 
-		return $this->container->setHtml($html);
+		return $this->container->setHtml($inputGroup);
 	}
 
 	protected function getCountryCodes()
@@ -142,24 +142,8 @@ class PhoneNumberInput extends BaseControl
 					$items = array_merge($items, $this->getCountryCodes());
 				}
 
-				$select = Helpers::createSelectBox($items, null, $value)
-					->addAttributes($attrs)
-					->setAttribute('class', 'phone-number-country-code')
-					->setAttribute('style', 'border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; padding-right: 0;');
-
-				$style = Html::el('style')->setHtml(
-					'.phone-number-country-code + .select2-container .select2-selection { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
-					. ' .phone-number-country-code + .select2-container { width: 100% !important; overflow: hidden; }'
-					. ' .phone-number-country-code + .select2-container .select2-selection__rendered { text-align: right; padding-right: 1.5em; }'
-					. ' .phone-number-country-code { margin-right: 0 !important; }'
-					. ' .row.g-2 > .col-5:has(.phone-number-country-code) { padding-right: 0 !important; flex: 0 0 20%; max-width: 20%; }'
-					. ' .row.g-2 > .col-7:has([name$="NationalNumber"]) { padding-left: 0 !important; flex: 0 0 80%; max-width: 80%; }'
-				);
-
-				$wrapper = Html::el();
-				$wrapper->addHtml($select);
-				$wrapper->addHtml($style);
-				return $wrapper;
+				return Helpers::createSelectBox($items, null, $value)
+					->addAttributes($attrs);
 
 			case self::CONTROL_NATIONAL_NUMBER:
 				if ($this->value instanceof PhoneNumber) {
@@ -172,7 +156,6 @@ class PhoneNumberInput extends BaseControl
 					'type' => 'tel',
 					'value' => $value,
 					'id' => $this->getHtmlId(),
-					'style' => 'border-top-left-radius: 0; border-bottom-left-radius: 0; padding-left: 0;',
 					'data-nette-rules' => \Nette\Forms\Helpers::exportRules($this->getRules()) ?: null,
 				], $attrs));
 		}

--- a/src/Forms/Controls/PhoneNumberInput.php
+++ b/src/Forms/Controls/PhoneNumberInput.php
@@ -88,14 +88,13 @@ class PhoneNumberInput extends BaseControl
 	 */
 	public function getControl()
 	{
-		$countryCode = $this->getControlPart(self::CONTROL_COUNTRY_CODE);
-		$nationalNumber = $this->getControlPart(self::CONTROL_NATIONAL_NUMBER);
+		$html = '';
 
-		$inputGroup = Html::el('div')->setAttribute('class', 'input-group');
-		$inputGroup->addHtml($countryCode);
-		$inputGroup->addHtml($nationalNumber);
+		foreach (self::CONTROLS as $key) {
+			$html .= $this->getControlPart($key);
+		}
 
-		return $this->container->setHtml($inputGroup);
+		return $this->container->setHtml($html);
 	}
 
 	protected function getCountryCodes()
@@ -143,8 +142,21 @@ class PhoneNumberInput extends BaseControl
 					$items = array_merge($items, $this->getCountryCodes());
 				}
 
-				return Helpers::createSelectBox($items, null, $value)
-					->addAttributes($attrs);
+				$select = Helpers::createSelectBox($items, null, $value)
+					->addAttributes($attrs)
+					->setAttribute('class', 'phone-number-country-code')
+					->setAttribute('style', 'border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; padding-right: 0;');
+
+				$style = Html::el('style')->setHtml(
+					'.phone-number-country-code + .select2-container .select2-selection { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
+					. ' .phone-number-country-code + .select2-container { width: 100% !important; overflow: hidden; }'
+					. ' .phone-number-country-code + .select2-container .select2-selection__rendered { text-align: right; padding-right: 1.5em; }'
+				);
+
+				$wrapper = Html::el();
+				$wrapper->addHtml($select);
+				$wrapper->addHtml($style);
+				return $wrapper;
 
 			case self::CONTROL_NATIONAL_NUMBER:
 				if ($this->value instanceof PhoneNumber) {
@@ -157,6 +169,7 @@ class PhoneNumberInput extends BaseControl
 					'type' => 'tel',
 					'value' => $value,
 					'id' => $this->getHtmlId(),
+					'style' => 'border-top-left-radius: 0; border-bottom-left-radius: 0; padding-left: 0;',
 					'data-nette-rules' => \Nette\Forms\Helpers::exportRules($this->getRules()) ?: null,
 				], $attrs));
 		}

--- a/src/Forms/Controls/PhoneNumberInput.php
+++ b/src/Forms/Controls/PhoneNumberInput.php
@@ -151,6 +151,9 @@ class PhoneNumberInput extends BaseControl
 					'.phone-number-country-code + .select2-container .select2-selection { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
 					. ' .phone-number-country-code + .select2-container { width: 100% !important; overflow: hidden; }'
 					. ' .phone-number-country-code + .select2-container .select2-selection__rendered { text-align: right; padding-right: 1.5em; }'
+					. ' .phone-number-country-code { margin-right: 0 !important; }'
+					. ' .row.g-2 > .col-5:has(.phone-number-country-code) { padding-right: 0 !important; }'
+					. ' .row.g-2 > .col-7:has([name$="NationalNumber"]) { padding-left: 0 !important; }'
 				);
 
 				$wrapper = Html::el();

--- a/src/Forms/Controls/PhoneNumberInput.php
+++ b/src/Forms/Controls/PhoneNumberInput.php
@@ -152,8 +152,8 @@ class PhoneNumberInput extends BaseControl
 					. ' .phone-number-country-code + .select2-container { width: 100% !important; overflow: hidden; }'
 					. ' .phone-number-country-code + .select2-container .select2-selection__rendered { text-align: right; padding-right: 1.5em; }'
 					. ' .phone-number-country-code { margin-right: 0 !important; }'
-					. ' .row.g-2 > .col-5:has(.phone-number-country-code) { padding-right: 0 !important; }'
-					. ' .row.g-2 > .col-7:has([name$="NationalNumber"]) { padding-left: 0 !important; }'
+					. ' .row.g-2 > .col-5:has(.phone-number-country-code) { padding-right: 0 !important; flex: 0 0 20%; max-width: 20%; }'
+					. ' .row.g-2 > .col-7:has([name$="NationalNumber"]) { padding-left: 0 !important; flex: 0 0 80%; max-width: 80%; }'
 				);
 
 				$wrapper = Html::el();

--- a/src/Forms/Controls/PhoneNumberInput.php
+++ b/src/Forms/Controls/PhoneNumberInput.php
@@ -45,10 +45,13 @@ class PhoneNumberInput extends BaseControl
 
 	protected $controls;
 
-	public static function addPhoneNumber(Container $container, $name, $label, $invalidPhoneNumberMessage)
+	protected bool $injectStyles = true;
+
+	public static function addPhoneNumber(Container $container, $name, $label, $invalidPhoneNumberMessage, bool $injectStyles = true)
 	{
 		$container->addComponent($control = new self($label), $name);
 
+		$control->injectStyles = $injectStyles;
 		$control->container = Html::el('div')->setAttribute('class', 'input-group phone-number-input-group');
 		$control->controls[static::CONTROL_COUNTRY_CODE] = Html::el();
 		$control->controls[static::CONTROL_NATIONAL_NUMBER] = Html::el();
@@ -96,15 +99,15 @@ class PhoneNumberInput extends BaseControl
 
 		$style = Html::el('style')->setHtml(
 		// Select (hidden by Select2, but keeps structure correct)
-			'.phone-number-input-group > select { flex: 0 0 25%; width: 25%; border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
+			'.phone-number-input-group > select { flex: 0 0 25% !important; width: 25% !important; border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
 			// Select2 container
-			. ' .phone-number-input-group > .select2-container { flex: 0 0 25%; width: 25% !important; }'
+			. ' .phone-number-input-group > .select2-container { flex: 0 0 25% !important; width: 25% !important; }'
 			. ' .phone-number-input-group > .select2-container .select2-selection { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
 			// Text input
-			. ' .phone-number-input-group > input[type="tel"] { flex: 0 0 75%; width: 75%; }'
+			. ' .phone-number-input-group > input[type="tel"] { flex: 0 0 75% !important; width: 75% !important; }'
 		);
 
-		return $this->container->setHtml($html . $style);
+		return $this->container->setHtml($html . ($this->injectStyles ? $style : ''));
 	}
 
 	protected function getCountryCodes()
@@ -166,14 +169,17 @@ class PhoneNumberInput extends BaseControl
 					// Select2: right radius 0
 					. ' .phone-number-country-code + .select2-container .select2-selection { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
 					. ' .phone-number-country-code + .select2-container { width: 100% !important; }'
-					// Native select: right radius 0
-					. ' .phone-number-country-code { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
+					// Native select: right radius 0, fill column width
+					. ' .phone-number-country-code { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; width: 100% !important; }'
 				);
 
-				$wrapper = Html::el();
-				$wrapper->addHtml($select);
-				$wrapper->addHtml($style);
-				return $wrapper;
+				if ($this->injectStyles) {
+					$wrapper = Html::el();
+					$wrapper->addHtml($select);
+					$wrapper->addHtml($style);
+					return $wrapper;
+				}
+				return $select;
 
 			case self::CONTROL_NATIONAL_NUMBER:
 				if ($this->value instanceof PhoneNumber) {
@@ -182,13 +188,16 @@ class PhoneNumberInput extends BaseControl
 					$value = $this->values[$key] ?? null;
 				}
 
-				return Html::el('input', array_merge([
+				$inputAttrs = [
 					'type' => 'tel',
 					'value' => $value,
 					'id' => $this->getHtmlId(),
-					'style' => 'border-top-left-radius: 0 !important; border-bottom-left-radius: 0 !important;',
 					'data-nette-rules' => \Nette\Forms\Helpers::exportRules($this->getRules()) ?: null,
-				], $attrs));
+				];
+				if ($this->injectStyles) {
+					$inputAttrs['style'] = 'border-top-left-radius: 0 !important; border-bottom-left-radius: 0 !important;';
+				}
+				return Html::el('input', array_merge($inputAttrs, $attrs));
 		}
 	}
 

--- a/src/Forms/Controls/PhoneNumberInput.php
+++ b/src/Forms/Controls/PhoneNumberInput.php
@@ -96,12 +96,12 @@ class PhoneNumberInput extends BaseControl
 
 		$style = Html::el('style')->setHtml(
 		// Select (hidden by Select2, but keeps structure correct)
-			'.phone-number-input-group > select { flex: 0 0 auto; width: auto; border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
+			'.phone-number-input-group > select { flex: 0 0 25%; width: 25%; border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
 			// Select2 container
-			. ' .phone-number-input-group > .select2-container { flex: 0 0 auto; }'
+			. ' .phone-number-input-group > .select2-container { flex: 0 0 25%; width: 25% !important; }'
 			. ' .phone-number-input-group > .select2-container .select2-selection { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
 			// Text input
-			. ' .phone-number-input-group > input[type="tel"] { flex: 1 1 auto; border-top-left-radius: 0 !important; border-bottom-left-radius: 0 !important; }'
+			. ' .phone-number-input-group > input[type="tel"] { flex: 0 0 75%; width: 75%; }'
 		);
 
 		return $this->container->setHtml($html . $style);
@@ -152,8 +152,28 @@ class PhoneNumberInput extends BaseControl
 					$items = array_merge($items, $this->getCountryCodes());
 				}
 
-				return Helpers::createSelectBox($items, null, $value)
-					->addAttributes($attrs);
+				$select = Helpers::createSelectBox($items, null, $value)
+					->addAttributes($attrs)
+					->setAttribute('class', 'phone-number-country-code');
+
+				$style = Html::el('style')->setHtml(
+				// Make the row behave like input-group
+					'.row:has(.phone-number-country-code) { --bs-gutter-x: 0 !important; flex-wrap: nowrap !important; }'
+					// Select column: 25% width, no padding
+					. ' .row > [class^="col"]:has(.phone-number-country-code) { flex: 0 0 25% !important; max-width: 25% !important; padding: 0 !important; }'
+					// Input column: 75% width, no padding
+					. ' .row > [class^="col"]:has(input[type="tel"]) { flex: 0 0 75% !important; max-width: 75% !important; padding: 0 !important; }'
+					// Select2: right radius 0
+					. ' .phone-number-country-code + .select2-container .select2-selection { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
+					. ' .phone-number-country-code + .select2-container { width: 100% !important; }'
+					// Native select: right radius 0
+					. ' .phone-number-country-code { border-top-right-radius: 0 !important; border-bottom-right-radius: 0 !important; }'
+				);
+
+				$wrapper = Html::el();
+				$wrapper->addHtml($select);
+				$wrapper->addHtml($style);
+				return $wrapper;
 
 			case self::CONTROL_NATIONAL_NUMBER:
 				if ($this->value instanceof PhoneNumber) {
@@ -166,6 +186,7 @@ class PhoneNumberInput extends BaseControl
 					'type' => 'tel',
 					'value' => $value,
 					'id' => $this->getHtmlId(),
+					'style' => 'border-top-left-radius: 0 !important; border-bottom-left-radius: 0 !important;',
 					'data-nette-rules' => \Nette\Forms\Helpers::exportRules($this->getRules()) ?: null,
 				], $attrs));
 		}


### PR DESCRIPTION
Modification of phon neumber input, now the select for country code and area for phone number are members of inputGroup. It allows rendering automatically or by calling getControl. This modification also allows user to bypass inner styling and have the inputs rendered manually.

When injectStyle is set to false and it is automatically rendered, the rendering should be just as was before.

When the input is rendered automatically and with injectStyles set to true, the inputs are rendered as intended. Right border of country code select touching left border of text input and left border of text input and right border of select having corner radius set to 0px.

Know issue:
When rendered by getControl, styles might not be correctly applied to corners of text area for phone number
When rendered by getControl in combination with infectStyles set to false, padding might not be properly set for parets of inputs and for some corners.